### PR TITLE
Changed parsing of issue body

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -972,7 +972,7 @@ PyYAML = ">=6.0,<7.0"
 
 [[package]]
 name = "pronto"
-version = "2.5.0"
+version = "2.5.1"
 description = "Python frontend to ontologies."
 category = "main"
 optional = false
@@ -2549,8 +2549,8 @@ prefixmaps = [
     {file = "prefixmaps-0.1.3.tar.gz", hash = "sha256:d5ab142b554ed6e70592b3ae1f6d9c652a5d25b9d46a813403a9cb3e83e992f2"},
 ]
 pronto = [
-    {file = "pronto-2.5.0-py2.py3-none-any.whl", hash = "sha256:d12b4164831177235899d4fc932b704b46aad7b3170b38d3412dd5da77d715c1"},
-    {file = "pronto-2.5.0.tar.gz", hash = "sha256:5abe43d2e663dfdc2eb7c649e895c016f87ce794a30596ad15f5c287948ba411"},
+    {file = "pronto-2.5.1-py2.py3-none-any.whl", hash = "sha256:e45a205e8dfa64500597e7d7f665419313060c0d4b4b7c247fe073c288256996"},
+    {file = "pronto-2.5.1.tar.gz", hash = "sha256:48bc8273a23b79dbf14bcdb5d194ca8cb236297887e0bba80f14d4b26c4121fa"},
 ]
 py = [
     {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "ontobot-change-agent"
-version = "0.2.1"
+version = "0.2.2"
 description = "Update ontologies using change language."
 
 authors = ["Harshad Hegde <hhegde@lbl.gov>"]

--- a/src/ontobot_change_agent/api.py
+++ b/src/ontobot_change_agent/api.py
@@ -97,15 +97,18 @@ def _extract_info_from_issue_object(issue: Issue) -> dict:
 
 
 def _make_sense_of_body(body: str) -> list:
-    splitter = "\r\n"
-    if "* " in body:
-        bullet = "* "
-    else:
-        bullet = "- "
-    splitter += bullet
+    # splitter = "\r\n"
+    # if "* " in body:
+    #     bullet = "* "
+    # else:
+    #     bullet = "- "
+    # splitter += bullet
 
+    # return (
+    #     body.lstrip(bullet).replace("<", "").replace(">", "").split(splitter)
+    # )
     return (
-        body.lstrip(bullet).replace("<", "").replace(">", "").split(splitter)
+        body.replace("<", "").replace(">", "").replace("\r\n", "")
     )
 
 

--- a/src/ontobot_change_agent/cli.py
+++ b/src/ontobot_change_agent/cli.py
@@ -150,10 +150,9 @@ def process_issue(
     for issue in get_issues(
         repository_name=repo, label=label, number=number, state=state
     ):
-        body_text = "\t".join(issue[BODY]).replace("\r\n", "")
 
-        begin_match = re.match(r"(.*)ontobot(.*)apply(.*): \*", body_text)
-        end_match = re.match(r"(.*)---", body_text)
+        begin_match = re.match(r"(.*)ontobot(.*)apply(.*): \*", issue[BODY])
+        end_match = re.match(r"(.*)---", issue[BODY])
 
         if begin_match:
             begin_index = begin_match.end() - 1
@@ -171,7 +170,7 @@ def process_issue(
             new_output = input
 
         if begin_index < end_index:
-            KGCL_COMMANDS = body_text[begin_index:end_index].split("* ")[1:]
+            KGCL_COMMANDS = issue[BODY][begin_index:end_index].split("* ")[1:]
             KGCL_COMMANDS = [x.strip() for x in KGCL_COMMANDS]
 
             if (


### PR DESCRIPTION
Initially the bullets made by `*` in th issues had a space preceding them and hence created some issues in implementing `ochange` . Also, now the text is parsed as a whole rather than `split()`ting into a list.