### PR TITLE
New way of extracting commands using `splitlines()`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 
 name = "ontobot-change-agent"
-version = "0.2.9"
+version = "0.3.0"
 description = "Update ontologies using change language."
 
 authors = ["Harshad Hegde <hhegde@lbl.gov>"]

--- a/src/ontobot_change_agent/api.py
+++ b/src/ontobot_change_agent/api.py
@@ -104,7 +104,7 @@ def _make_sense_of_body(body: str) -> str:
     # return (
     #     body.lstrip(bullet).replace("<", "").replace(">", "").split(splitter)
     # )
-    return body.replace("<", "").replace(">", "").replace("\r\n", "")
+    return body.replace("<", "").replace(">", "")
 
 
 def get_all_labels_from_repo(repository_name: str) -> dict:


### PR DESCRIPTION
Earlier there was a need for identifying an endpoint for commands. This PR does this differently:

```
KGCL_COMMANDS = [
            str(item).replace("* ", "") for item in issue[BODY].splitlines() if item.startswith("*")
        ]
```