### PR TITLE
Accept `-`& `*` as bullet markdown syntaxes

### DIFF
--- a/src/ontobot_change_agent/cli.py
+++ b/src/ontobot_change_agent/cli.py
@@ -141,9 +141,17 @@ def process_issue(input: str, repo: str, label: str, number: int, state: str, ou
     formatted_body = "The following commands were executed: </br>"
 
     for issue in get_issues(repository_name=repo, label=label, number=number, state=state):
-        KGCL_COMMANDS = [
-            str(item).replace("* ", "") for item in issue[BODY].splitlines() if item.startswith("*")
-        ]
+        bullet_starters = ["* ", "- "]
+        KGCL_COMMANDS = []
+        for bullet in bullet_starters:
+
+            KGCL_COMMANDS.extend(
+                [
+                    str(item).replace(bullet, "")
+                    for item in issue[BODY].splitlines()
+                    if item.startswith(bullet)
+                ]
+            )
         if output:
             new_output = output
         else:


### PR DESCRIPTION
Earlier version only identified `*` as a bullet in the issue markdown text. Now `-` is also considered.