### PR TITLE
Left-strip command bullets to match pattern

### DIFF
--- a/src/ontobot_change_agent/cli.py
+++ b/src/ontobot_change_agent/cli.py
@@ -168,7 +168,7 @@ def process_issue(
                         [
                             str(item).replace(bullet, "")
                             for item in issue[BODY].splitlines()
-                            if item.startswith(bullet)
+                            if item.lstrip().startswith(bullet)
                         ]
                     )
                 if output:


### PR DESCRIPTION
When there was a <space> preceding the bullet in the issue (`-` or `*`), the command would not be found by `ontobot`.

Fix: `strip()` the description items.