### PR TITLE
Compatible with kgcl-java 0.2.0

### DIFF
--- a/src/ontobot_change_agent/api.py
+++ b/src/ontobot_change_agent/api.py
@@ -240,14 +240,15 @@ def process_issue_via_jar(input: str, commands: list, jar_path: str, output: str
     :param commands: A list of commands.
     :param output: Path to where the output is written, defaults to None
     """
-    cli_command = 'java -jar {} apply -i {} -k "{}"'.format(
-        jar_path, input, commands[0].replace('"', "'")
+    cli_command = 'java -jar {} apply -i {}'.format(
+        jar_path, input
     )
     cli_commands = [
-        ' apply -k "{}"'.format(command.replace('"', "'"))
-        for command in commands[1:]
+        ' -k "{}"'.format(command.replace('"', "'"))
+        for command in commands
         if len(commands) > 1
     ]
+    import pdb; pdb.set_trace()
     full_command = cli_command + " ".join(cli_commands) + f" -o {output}"
     # Run the command on the command line
     subprocess.run(full_command, shell=True)  # noqa S602

--- a/src/ontobot_change_agent/api.py
+++ b/src/ontobot_change_agent/api.py
@@ -240,15 +240,13 @@ def process_issue_via_jar(input: str, commands: list, jar_path: str, output: str
     :param commands: A list of commands.
     :param output: Path to where the output is written, defaults to None
     """
-    cli_command = 'java -jar {} apply -i {}'.format(
-        jar_path, input
-    )
+    cli_command = "java -jar {} apply -i {}".format(jar_path, input)
     cli_commands = [
-        ' -k "{}"'.format(command.replace('"', "'"))
-        for command in commands
-        if len(commands) > 1
+        ' -k "{}"'.format(command.replace('"', "'")) for command in commands if len(commands) > 1
     ]
-    import pdb; pdb.set_trace()
+    import pdb
+
+    pdb.set_trace()
     full_command = cli_command + " ".join(cli_commands) + f" -o {output}"
     # Run the command on the command line
     subprocess.run(full_command, shell=True)  # noqa S602


### PR DESCRIPTION
This PR is in response to  https://github.com/gouttegd/kgcl-java/releases/tag/kgcl-0.2.0 release:
```
ROBOT apply command:
- Allow using -k and/or -K options more than once.

```

This makes the code a little more clean.